### PR TITLE
Bugfix 5.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Explanation of using the tool length probe subroutine for Probe Basic and other GUIs from TooTall18T .  
-Version 5.0.1 as of 17.02.2025  
+Version 5.0.2 as of 08.03.2025  
 https://github.com/TooTall18T/tool_length_probe
 
 ---
@@ -63,6 +63,11 @@ By using other GUIs all settings need to be made in the subroutine.
 
 ---
 ## Last change:
+V5.0.2
+- tool_touch_off.ngc:
+    - Added "G43" to same tool exit to make sure that after the routine is finished G43 is on.
+    - Added bridging of the routine when no program is running.
+
 V5.0.1
 - tool_touch_off.ngc: Added "M50 P1" to returns to unlock the feed lock
 

--- a/lies_mich.md
+++ b/lies_mich.md
@@ -1,5 +1,5 @@
 # Erklärung zur Nutzung der Werkzeugvermessungsroutine für Probe Basic und anderen GUIs von TooTall18T .  
-Version 5.0.1 stand 17.02.2025  
+Version 5.0.2 stand 08.03.2025  
 https://github.com/TooTall18T/tool_length_probe
 
   
@@ -63,6 +63,11 @@ Bei der Benutzung einer anderen GUI werden alle Einstellungen in der Subroutine 
   
 ---
 ## Letzte Änderung:
+V5.0.2
+- tool_touch_off.ngc:
+	- "G43" zu Selbes Werkzeug hinzugefügt, um sicher zu stellen, dass G43 beim Beenden der Routine AN ist.
+ 	- Überbrückung der Routine, wenn kein Programm läuft, hinzugefügt.
+
 V5.0.1
 - tool_touch_off.ngc: "M50 P1" zu den returns hinzugefügt, um die Vorschubssperre aufzuheben
 

--- a/tool_touch_off.ngc
+++ b/tool_touch_off.ngc
@@ -1,6 +1,6 @@
 ;Subprogram for manual tool change with measurement of the tool.
-;Version date: 2025-02-17
-;Version: 5.0.1
+;Version date: 2025-03-08
+;Version: 5.0.2
 ;https://github.com/TooTall18T/tool_length_probe
 
 ;This subprogram is based on the original subprogram "tool_touch_off.ngc" that came with Probe Basic.
@@ -13,6 +13,9 @@
 
 
 o<tool_touch_off> sub
+;Ensures that the routine is not run when checking the CNC program. 
+;This can sometimes lead to unjustified errors.
+o<400> if [#<_task> EQ 1]
 
 ;-1- Fixed parameters
 ;-MAIN-
@@ -133,6 +136,7 @@ M50 P0
 ;If the tool in the spindle is the same as the one selected, no change is made. Except for manual measurement.
 o<90> if [#<mode> EQ 1]
   o<92> if [#<tool_in_spindle> EQ #<tool_selected>]
+    G43
     (DEBUG, Same tool)
     ;(DEBUG, Selbes Werkzeug)
     o<94> if [ #<brake_after_M600> EQ 1]     
@@ -375,6 +379,7 @@ M50 P1
 
 (LOG, END)
 (LOGCLOSE)
+o<400> endif
 o<tool_touch_off> endsub
 
 M2 (end program)


### PR DESCRIPTION
Added "G43" to same tool exit to make sure that after the routine is finished G43 is on.

Added bridging of the routine when no program is running. Ensures that the routine is not run when checking the CNC program. This can sometimes lead to unjustified errors.